### PR TITLE
+ Fix NotSuchFieldException

### DIFF
--- a/src/main/java/com/modularwarfare/client/scope/ScopeRenderGlobal.java
+++ b/src/main/java/com/modularwarfare/client/scope/ScopeRenderGlobal.java
@@ -20,7 +20,7 @@ public class ScopeRenderGlobal extends RenderGlobal {
     public ScopeRenderGlobal(Minecraft mcIn) {
         super(mcIn);
         try {
-            fieldRenderDistanceChunks = getClass().getSuperclass().getDeclaredField("renderDistanceChunks");
+            fieldRenderDistanceChunks = getClass().getSuperclass().getDeclaredField("field_72739_F"); // Fix NotSuchFieldException
             fieldRenderDistanceChunks.setAccessible(true);
         } catch (NoSuchFieldException e) {
             e.printStackTrace();


### PR DESCRIPTION
When i aim with a weapon i get a weird NotSuchFieldException 
I fixxed this when i used the obfuscated name of renderDistanceChunks

`[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: java.lang.NoSuchFieldException: renderDistanceChunks
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at java.lang.Class.getDeclaredField(Class.java:2070)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.modularwarfare.client.scope.ScopeRenderGlobal.<init>(ScopeRenderGlobal.java:23)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.modularwarfare.client.scope.ScopeUtils.<clinit>(ScopeUtils.java:33)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.modularwarfare.client.ClientProxy.load(ClientProxy.java:236)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.modularwarfare.ModularWarfare.onInitialization(ModularWarfare.java:348)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at java.lang.reflect.Method.invoke(Method.java:497)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraftforge.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:637)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at java.lang.reflect.Method.invoke(Method.java:497)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraftforge.fml.common.LoadController.sendEventToModContainer(LoadController.java:219)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraftforge.fml.common.LoadController.propogateStateMessage(LoadController.java:197)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at java.lang.reflect.Method.invoke(Method.java:497)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:136)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraftforge.fml.common.Loader.initializeMods(Loader.java:749)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraftforge.fml.client.FMLClientHandler.finishMinecraftLoading(FMLClientHandler.java:336)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:535)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:378)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraft.client.main.Main.main(SourceFile:123)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at java.lang.reflect.Method.invoke(Method.java:497)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
[17:44:04] [Client thread/INFO] [STDERR]: [com.modularwarfare.client.scope.ScopeRenderGlobal:<init>:26]: 	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)`
