### PR TITLE
Dont render weapon on back when configuration option is false

### DIFF
--- a/src/main/java/com/modularwarfare/ModConfig.java
+++ b/src/main/java/com/modularwarfare/ModConfig.java
@@ -33,6 +33,7 @@ public class ModConfig {
     public Guns guns = new Guns();
     public static class Guns {
         public boolean guns_interaction_hand = true;
+        public boolean render_weapon_on_back = true;
     }
 
     //drops

--- a/src/main/java/com/modularwarfare/client/model/layers/RenderLayerBody.java
+++ b/src/main/java/com/modularwarfare/client/model/layers/RenderLayerBody.java
@@ -1,5 +1,6 @@
 package com.modularwarfare.client.model.layers;
 
+import com.modularwarfare.ModConfig;
 import com.modularwarfare.ModularWarfare;
 import com.modularwarfare.client.ClientRenderHooks;
 import com.modularwarfare.client.model.ModelCustomArmor;
@@ -49,33 +50,35 @@ public class RenderLayerBody implements LayerRenderer<EntityPlayer> {
             }
         }
 
-        if (player instanceof AbstractClientPlayer) {
-            ItemStack gun = BackWeaponsManager.INSTANCE
-                    .getItemToRender((AbstractClientPlayer) player);
-            if (gun != ItemStack.EMPTY && !gun.isEmpty()) {
-                BaseType type = ((BaseItem) gun.getItem()).baseType;
-                {
-                    GlStateManager.pushMatrix();
-                    if (ClientRenderHooks.customRenderers[type.id] != null) {
-                        GlStateManager.translate(0, -0.6, 0.35);
-                        boolean isSneaking = player.isSneaking();
-                        if (player instanceof EntityPlayerSP) {
-                            ((EntityPlayerSP) player).movementInput.sneak = false;
-                        } else {
-                            player.setSneaking(false);
+        if(ModConfig.INSTANCE.guns.render_weapon_on_back) {
+            if (player instanceof AbstractClientPlayer) {
+                ItemStack gun = BackWeaponsManager.INSTANCE
+                        .getItemToRender((AbstractClientPlayer) player);
+                if (gun != ItemStack.EMPTY && !gun.isEmpty()) {
+                    BaseType type = ((BaseItem) gun.getItem()).baseType;
+                    {
+                        GlStateManager.pushMatrix();
+                        if (ClientRenderHooks.customRenderers[type.id] != null) {
+                            GlStateManager.translate(0, -0.6, 0.35);
+                            boolean isSneaking = player.isSneaking();
+                            if (player instanceof EntityPlayerSP) {
+                                ((EntityPlayerSP) player).movementInput.sneak = false;
+                            } else {
+                                player.setSneaking(false);
+                            }
+                            ClientRenderHooks.customRenderers[type.id].renderItem(CustomItemRenderType.BACK, null, gun, player.world,
+                                    player, partialTicks);
+                            if (player instanceof EntityPlayerSP) {
+                                ((EntityPlayerSP) player).movementInput.sneak = isSneaking;
+                            } else {
+                                player.setSneaking(isSneaking);
+                            }
                         }
-                        ClientRenderHooks.customRenderers[type.id].renderItem(CustomItemRenderType.BACK, null, gun, player.world,
-                                player, partialTicks);
-                        if (player instanceof EntityPlayerSP) {
-                            ((EntityPlayerSP) player).movementInput.sneak = isSneaking;
-                        } else {
-                            player.setSneaking(isSneaking);
-                        }
+                        GlStateManager.popMatrix();
                     }
-                    GlStateManager.popMatrix();
                 }
-            }
 
+            }
         }
     }
 

--- a/src/main/java/com/modularwarfare/common/handler/ServerTickHandler.java
+++ b/src/main/java/com/modularwarfare/common/handler/ServerTickHandler.java
@@ -1,5 +1,6 @@
 package com.modularwarfare.common.handler;
 
+import com.modularwarfare.ModConfig;
 import com.modularwarfare.ModularWarfare;
 import com.modularwarfare.common.network.BackWeaponsManager;
 import com.modularwarfare.common.network.PacketAimingReponse;
@@ -26,10 +27,12 @@ public class ServerTickHandler extends ForgeEvent {
     @SubscribeEvent
     public void onServerTick(ServerTickEvent event) {
         {
-            long currentTime = System.currentTimeMillis();
-            if (lastBackWeaponsSync == -1 || currentTime - this.lastBackWeaponsSync > 1000) {
-                this.lastBackWeaponsSync = currentTime;
-                BackWeaponsManager.INSTANCE.collect().sync();
+            if(ModConfig.INSTANCE.guns.render_weapon_on_back) {
+                long currentTime = System.currentTimeMillis();
+                if (lastBackWeaponsSync == -1 || currentTime - this.lastBackWeaponsSync > 1000) {
+                    this.lastBackWeaponsSync = currentTime;
+                    BackWeaponsManager.INSTANCE.collect().sync();
+                }
             }
         }
         switch (event.phase) {


### PR DESCRIPTION
when the configuration option is set to false
- the server sync will not be called
- clientside ingame render will not be called